### PR TITLE
feat(jsdoc): add support for custom file options in jsdoc function

### DIFF
--- a/src/configs/jsdoc.ts
+++ b/src/configs/jsdoc.ts
@@ -1,14 +1,17 @@
-import type { OptionsStylistic, TypedFlatConfigItem } from '../types'
+import type { OptionsFiles, OptionsStylistic, TypedFlatConfigItem } from '../types'
+import { GLOB_JS } from '../globs'
 
 import { interopDefault } from '../utils'
 
-export async function jsdoc(options: OptionsStylistic = {}): Promise<TypedFlatConfigItem[]> {
+export async function jsdoc(options: OptionsStylistic & OptionsFiles = {}): Promise<TypedFlatConfigItem[]> {
   const {
+    files = [GLOB_JS],
     stylistic = true,
   } = options
 
   return [
     {
+      files,
       name: 'antfu/jsdoc/rules',
       plugins: {
         jsdoc: await interopDefault(import('eslint-plugin-jsdoc')),


### PR DESCRIPTION
This pull request includes changes to the `src/configs/jsdoc.ts` file to enhance the configuration options for JSDoc. The most important changes are the addition of a new import and the extension of the `jsdoc` function to support file glob patterns.

Enhancements to JSDoc configuration:

* Added `OptionsFiles` type import and `GLOB_JS` constant from `../globs`.
* Modified the `jsdoc` function to accept `OptionsFiles` in addition to `OptionsStylistic`, allowing for file glob patterns to be specified.
* Set a default value for the `files` option to `[GLOB_JS]` within the `jsdoc` function.
* Included the `files` option in the returned configuration object within the `jsdoc` function.