### PR TITLE
feat: add support for custom file options in jsdoc function

### DIFF
--- a/src/configs/jsdoc.ts
+++ b/src/configs/jsdoc.ts
@@ -1,14 +1,17 @@
-import type { OptionsStylistic, TypedFlatConfigItem } from '../types'
+import type { OptionsFiles, OptionsStylistic, TypedFlatConfigItem } from '../types'
+import { GLOB_JS } from '../globs'
 
 import { interopDefault } from '../utils'
 
-export async function jsdoc(options: OptionsStylistic = {}): Promise<TypedFlatConfigItem[]> {
+export async function jsdoc(options: OptionsStylistic & OptionsFiles = {}): Promise<TypedFlatConfigItem[]> {
   const {
+    files = [GLOB_JS],
     stylistic = true,
   } = options
 
   return [
     {
+      files,
       name: 'antfu/jsdoc/rules',
       plugins: {
         jsdoc: await interopDefault(import('eslint-plugin-jsdoc')),


### PR DESCRIPTION
This pull request includes changes to the `src/configs/jsdoc.ts` file to enhance the configuration options for JSDoc. The most important changes include the addition of a new type import, a new constant import, and modifications to the `jsdoc` function to support additional options.

Enhancements to JSDoc configuration:

* [`src/configs/jsdoc.ts`](diffhunk://#diff-d7f77217c37d715bbe9eb3aa9ab3a5cca4d82ada89074daf44894a4ca832bfc2L1-R14): Added the `OptionsFiles` type import and the `GLOB_JS` constant import to support file glob patterns.
* [`src/configs/jsdoc.ts`](diffhunk://#diff-d7f77217c37d715bbe9eb3aa9ab3a5cca4d82ada89074daf44894a4ca832bfc2L1-R14): Updated the `jsdoc` function to accept the `OptionsFiles` type in addition to `OptionsStylistic`, and set a default value for the `files` option.
* [`src/configs/jsdoc.ts`](diffhunk://#diff-d7f77217c37d715bbe9eb3aa9ab3a5cca4d82ada89074daf44894a4ca832bfc2L1-R14): Included the `files` option in the returned configuration object for JSDoc rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the documentation tool's configuration by introducing customizable file handling options by default. This update enables a more tailored and user-friendly documentation process.
  
- **Refactor**
  - Streamlined the configuration setup by unifying related settings, promoting consistency and ease of use. These improvements result in a smoother workflow and ensure efficient, reliable documentation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->