### PR TITLE
chore: update package references from antfu to thewlabs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-PRESENT Anthony Fu<https://github.com/antfu>
+Copyright (c) 2019-PRESENT Wilfried AGO<https://github.com/wilfriedago>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# @antfu/eslint-config
+# eslint-config-thewlabs
 
-[![npm](https://img.shields.io/npm/v/@antfu/eslint-config?color=444&label=)](https://npmjs.com/package/@antfu/eslint-config) [![code style](https://antfu.me/badge-code-style.svg)](https://github.com/antfu/eslint-config)
+[![npm](https://img.shields.io/npm/v/eslint-config-thewlabs?color=444&label=)](https://npmjs.com/package/eslint-config-thewlabs) [![code style](https://thewlabs.me/badge-code-style.svg)](https://github.com/thewlabs/eslint-config-thewlabs)
 
 - Auto fix for formatting (aimed to be used standalone **without** Prettier)
 - Reasonable defaults, best practices, only one line of config
 - Designed to work with TypeScript, JSX, Vue, JSON, YAML, Toml, Markdown, etc. Out-of-box.
 - Opinionated, but [very customizable](#customization)
 - [ESLint Flat config](https://eslint.org/docs/latest/use/configure/configuration-files-new), compose easily!
-- Optional [React](#react), [Svelte](#svelte), [UnoCSS](#unocss), [Astro](#astro), [Solid](#solid) support
+- Optional [React](#react), [Angular](#angular), [Svelte](#svelte), [UnoCSS](#unocss), [Astro](#astro), [Solid](#solid) support
 - Optional [formatters](#formatters) support for formatting CSS, HTML, XML, etc.
 - **Style principle**: Minimal for reading, stable for diff, consistent
   - Sorted imports, dangling commas
@@ -17,7 +17,7 @@
 - Requires ESLint v9.5.0+
 
 > [!NOTE]
-> Since v1.0.0, this config is rewritten to the new [ESLint Flat config](https://eslint.org/docs/latest/use/configure/configuration-files-new), check the [release note](https://github.com/antfu/eslint-config/releases/tag/v1.0.0) for more details.
+> Since v1.0.0, this config is rewritten to the new [ESLint Flat config](https://eslint.org/docs/latest/use/configure/configuration-files-new), check the [release note](https://github.com/thewlabs/eslint-config/releases/tag/v1.0.0) for more details.
 >
 > Since v3.0.0, ESLint v9.5.0+ is now required.
 
@@ -35,7 +35,7 @@
 We provided a CLI tool to help you set up your project, or migrate from the legacy config to the new flat config with one command.
 
 ```bash
-pnpm dlx @antfu/eslint-config@latest
+pnpm dlx eslint-config-thewlabs@latest
 ```
 
 ### Manual Install
@@ -43,16 +43,16 @@ pnpm dlx @antfu/eslint-config@latest
 If you prefer to set up manually:
 
 ```bash
-pnpm i -D eslint @antfu/eslint-config
+pnpm i -D eslint eslint-config-thewlabs
 ```
 
 And create `eslint.config.mjs` in your project root:
 
 ```js
 // eslint.config.mjs
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu()
+export default thewlabs()
 ```
 
 <details>
@@ -63,13 +63,13 @@ Combined with legacy config:
 If you still use some configs from the legacy eslintrc format, you can use the [`@eslint/eslintrc`](https://www.npmjs.com/package/@eslint/eslintrc) package to convert them to the flat config.
 
 ```js
-// eslint.config.mjs
-import antfu from '@antfu/eslint-config'
 import { FlatCompat } from '@eslint/eslintrc'
+// eslint.config.mjs
+import thewlabs from 'eslint-config-thewlabs'
 
 const compat = new FlatCompat()
 
-export default antfu(
+export default thewlabs(
   {
     ignores: [],
   },
@@ -255,22 +255,22 @@ lspconfig.eslint.setup({
 
 Since v1.0, we migrated to [ESLint Flat config](https://eslint.org/docs/latest/use/configure/configuration-files-new). It provides much better organization and composition.
 
-Normally you only need to import the `antfu` preset:
+Normally you only need to import the `thewlabs` preset:
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu()
+export default thewlabs()
 ```
 
 And that's it! Or you can configure each integration individually, for example:
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu({
+export default thewlabs({
 // Type of the project. 'lib' for libraries, the default is 'app'
   type: 'lib',
 
@@ -299,15 +299,15 @@ export default antfu({
 })
 ```
 
-The `antfu` factory function also accepts any number of arbitrary custom config overrides:
+The `thewlabs` factory function also accepts any number of arbitrary custom config overrides:
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu(
+export default thewlabs(
   {
-    // Configures for antfu's config
+    // Configures for thewlabs's config
   },
 
   // From the second arguments they are ESLint Flat Configs
@@ -349,7 +349,7 @@ import {
   unicorn,
   vue,
   yaml,
-} from '@antfu/eslint-config'
+} from 'eslint-config-thewlabs'
 
 export default combine(
   ignores(),
@@ -371,7 +371,7 @@ export default combine(
 
 </details>
 
-Check out the [configs](https://github.com/antfu/eslint-config/blob/main/src/configs) and [factory](https://github.com/antfu/eslint-config/blob/main/src/factory.ts) for more details.
+Check out the [configs](https://github.com/thewlabs/eslint-config-thewlabs/blob/main/src/configs) and [factory](https://github.com/thewlabs/eslint-config-thewlabs/blob/main/src/factory.ts) for more details.
 
 > Thanks to [sxzz/eslint-config](https://github.com/sxzz/eslint-config) for the inspiration and reference.
 
@@ -379,15 +379,17 @@ Check out the [configs](https://github.com/antfu/eslint-config/blob/main/src/con
 
 Since flat config requires us to explicitly provide the plugin names (instead of the mandatory convention from npm package name), we renamed some plugins to make the overall scope more consistent and easier to write.
 
-| New Prefix | Original Prefix        | Source Plugin                                                                              |
-| ---------- | ---------------------- | ------------------------------------------------------------------------------------------ |
-| `import/*` | `import-x/*`           | [eslint-plugin-import-x](https://github.com/un-es/eslint-plugin-import-x)                  |
-| `node/*`   | `n/*`                  | [eslint-plugin-n](https://github.com/eslint-community/eslint-plugin-n)                     |
-| `yaml/*`   | `yml/*`                | [eslint-plugin-yml](https://github.com/ota-meshi/eslint-plugin-yml)                        |
-| `ts/*`     | `@typescript-eslint/*` | [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint) |
-| `style/*`  | `@stylistic/*`         | [@stylistic/eslint-plugin](https://github.com/eslint-stylistic/eslint-stylistic)           |
-| `test/*`   | `vitest/*`             | [@vitest/eslint-plugin](https://github.com/vitest-dev/eslint-plugin-vitest)                |
-| `test/*`   | `no-only-tests/*`      | [eslint-plugin-no-only-tests](https://github.com/levibuzolic/eslint-plugin-no-only-tests)  |
+| New Prefix           | Original Prefix              | Source Plugin                                                                              |
+| -------------------- | ---------------------------- | ------------------------------------------------------------------------------------------ |
+| `import/*`           | `import-x/*`                 | [eslint-plugin-import-x](https://github.com/un-es/eslint-plugin-import-x)                  |
+| `node/*`             | `n/*`                        | [eslint-plugin-n](https://github.com/eslint-community/eslint-plugin-n)                     |
+| `yaml/*`             | `yml/*`                      | [eslint-plugin-yml](https://github.com/ota-meshi/eslint-plugin-yml)                        |
+| `ts/*`               | `@typescript-eslint/*`       | [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint) |
+| `style/*`            | `@stylistic/*`               | [@stylistic/eslint-plugin](https://github.com/eslint-stylistic/eslint-stylistic)           |
+| `test/*`             | `vitest/*`                   | [@vitest/eslint-plugin](https://github.com/vitest-dev/eslint-plugin-vitest)                |
+| `test/*`             | `no-only-tests/*`            | [eslint-plugin-no-only-tests](https://github.com/levibuzolic/eslint-plugin-no-only-tests)  |
+| `angular/*`          | `@angular-eslint/*`          | [@angular-eslint/eslint-plugin](https://github.com/angular-eslint/angular-eslint)          |
+| `angular/template/*` | `@angular-eslint/template/*` | [@angular-eslint/eslint-plugin-template](https://github.com/angular-eslint/angular-eslint) |
 
 When you want to override rules, or disable them inline, you need to update to the new prefix:
 
@@ -414,9 +416,9 @@ Since v2.9.0, this preset will automatically rename the plugins also for your cu
 If you really want to use the original prefix, you can revert the plugin renaming by:
 
 ```ts
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu()
+export default thewlabs()
   .renamePlugins({
     ts: '@typescript-eslint',
     yaml: 'yml',
@@ -433,9 +435,9 @@ Certain rules would only be enabled in specific files, for example, `ts/*` rules
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu(
+export default thewlabs(
   {
     vue: true,
     typescript: true
@@ -460,9 +462,9 @@ We also provided the `overrides` options in each integration to make it easier:
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu({
+export default thewlabs({
   vue: {
     overrides: {
       'vue/operator-linebreak': ['error', 'before'],
@@ -483,19 +485,19 @@ export default antfu({
 
 ### Config Composer
 
-Since v2.10.0, the factory function `antfu()` returns a [`FlatConfigComposer` object from `eslint-flat-config-utils`](https://github.com/antfu/eslint-flat-config-utils#composer) where you can chain the methods to compose the config even more flexibly.
+Since v2.10.0, the factory function `thewlabs()` returns a [`FlatConfigComposer` object from `eslint-flat-config-utils`](https://github.com/thewlabs/eslint-flat-config-utils#composer) where you can chain the methods to compose the config even more flexibly.
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu()
+export default thewlabs()
   .prepend(
     // some configs before the main config
   )
   // overrides any named configs
   .override(
-    'antfu/imports',
+    'thewlabs/imports',
     {
       rules: {
         'import/order': ['error', { 'newlines-between': 'always' }],
@@ -516,9 +518,9 @@ Vue support is detected automatically by checking if `vue` is installed in your 
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu({
+export default thewlabs({
   vue: true
 })
 ```
@@ -529,9 +531,9 @@ We have limited support for Vue 2 (as it's already [reached EOL](https://v2.vuej
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu({
+export default thewlabs({
   vue: {
     vueVersion: 2
   },
@@ -546,9 +548,9 @@ To enable Vue accessibility support, you need to explicitly turn it on:
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu({
+export default thewlabs({
   vue: {
     a11y: true
   },
@@ -567,13 +569,13 @@ We provide some optional configs for specific use cases, that we don't include t
 
 #### Formatters
 
-Use external formatters to format files that ESLint cannot handle yet (`.css`, `.html`, etc). Powered by [`eslint-plugin-format`](https://github.com/antfu/eslint-plugin-format).
+Use external formatters to format files that ESLint cannot handle yet (`.css`, `.html`, etc). Powered by [`eslint-plugin-format`](https://github.com/thewlabs/eslint-plugin-format).
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu({
+export default thewlabs({
   formatters: {
     /**
      * Format CSS, LESS, SCSS files, also the `<style>` blocks in Vue
@@ -607,9 +609,9 @@ To enable React support, you need to explicitly turn it on:
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu({
+export default thewlabs({
   react: true,
 })
 ```
@@ -626,9 +628,9 @@ To enable svelte support, you need to explicitly turn it on:
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu({
+export default thewlabs({
   svelte: true,
 })
 ```
@@ -645,9 +647,9 @@ To enable astro support, you need to explicitly turn it on:
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu({
+export default thewlabs({
   astro: true,
 })
 ```
@@ -664,9 +666,9 @@ To enable Solid support, you need to explicitly turn it on:
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu({
+export default thewlabs({
   solid: true,
 })
 ```
@@ -683,9 +685,9 @@ To enable UnoCSS support, you need to explicitly turn it on:
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu({
+export default thewlabs({
   unocss: true,
 })
 ```
@@ -702,7 +704,7 @@ This config also provides some optional plugins/rules for extended usage.
 
 #### `command`
 
-Powered by [`eslint-plugin-command`](https://github.com/antfu/eslint-plugin-command). It is not a typical rule for linting, but an on-demand micro-codemod tool that triggers by specific comments.
+Powered by [`eslint-plugin-command`](https://github.com/thewlabs/eslint-plugin-command). It is not a typical rule for linting, but an on-demand micro-codemod tool that triggers by specific comments.
 
 For a few triggers, for example:
 
@@ -711,7 +713,7 @@ For a few triggers, for example:
 - `/// to-for-each` - converts a for-in/for-of loop to `.forEach()`
 - `/// to-for-of` - converts a `.forEach()` to a for-of loop
 - `/// keep-sorted` - sorts an object/array/interface
-- ... etc. - refer to the [documentation](https://github.com/antfu/eslint-plugin-command#built-in-commands)
+- ... etc. - refer to the [documentation](https://github.com/thewlabs/eslint-plugin-command#built-in-commands)
 
 You can add the trigger comment one line above the code you want to transform, for example (note the triple slash):
 
@@ -740,9 +742,9 @@ You can optionally enable the [type aware rules](https://typescript-eslint.io/li
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu({
+export default thewlabs({
   typescript: {
     tsconfigPath: 'tsconfig.json',
   },
@@ -757,15 +759,15 @@ Auto-fixing for the following rules are disabled when ESLint is running in a cod
 - [`test/no-only-tests`](https://github.com/levibuzolic/eslint-plugin-no-only-tests)
 - [`unused-imports/no-unused-imports`](https://www.npmjs.com/package/eslint-plugin-unused-imports)
 
-Since v3.16.0, they are no longer disabled, but made non-fixable using [this helper](https://github.com/antfu/eslint-flat-config-utils#composerdisablerulesfix).
+Since v3.16.0, they are no longer disabled, but made non-fixable using [this helper](https://github.com/thewlabs/eslint-flat-config-utils#composerdisablerulesfix).
 
 This is to prevent unused imports from getting removed by the editor during refactoring to get a better developer experience. Those rules will be applied when you run ESLint in the terminal or [Lint Staged](#lint-staged). If you don't want this behavior, you can disable them:
 
 ```js
 // eslint.config.js
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu({
+export default thewlabs({
   isInEditor: false
 })
 ```
@@ -826,16 +828,16 @@ This project follows [Semantic Versioning](https://semver.org/) for releases. Ho
 If you enjoy this code style, and would like to mention it in your project, here is the badge you can use:
 
 ```md
-[![code style](https://antfu.me/badge-code-style.svg)](https://github.com/antfu/eslint-config)
+[![code style](https://thewlabs.me/badge-code-style.svg)](https://github.com/thewlabs/eslint-config)
 ```
 
-[![code style](https://antfu.me/badge-code-style.svg)](https://github.com/antfu/eslint-config)
+[![code style](https://thewlabs.me/badge-code-style.svg)](https://github.com/thewlabs/eslint-config)
 
 ## FAQ
 
 ### Prettier?
 
-[Why I don't use Prettier](https://antfu.me/posts/why-not-prettier)
+[Why I don't use Prettier](https://thewlabs.me/posts/why-not-prettier)
 
 Well, you can still use Prettier to format files that are not supported well by ESLint yet, such as `.css`, `.html`, etc. See [formatters](#formatters) for more details.
 
@@ -856,9 +858,9 @@ I am a very opinionated person, so as this config. I prefer the top-level functi
 I know they are not necessarily the popular opinions. If you really want to get rid of them, you can disable them with:
 
 ```ts
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu({
+export default thewlabs({
   lessOpinionated: true
 })
 ```
@@ -867,13 +869,6 @@ export default antfu({
 
 Sure, you can configure and override rules locally in your project to fit your needs. If that still does not work for you, you can always fork this repo and maintain your own.
 
-## Check Also
-
-- [antfu/dotfiles](https://github.com/antfu/dotfiles) - My dotfiles
-- [antfu/vscode-settings](https://github.com/antfu/vscode-settings) - My VS Code settings
-- [antfu/starter-ts](https://github.com/antfu/starter-ts) - My starter template for TypeScript library
-- [antfu/vitesse](https://github.com/antfu/vitesse) - My starter template for Vue & Vite app
-
 ## License
 
-[MIT](./LICENSE) License &copy; 2019-PRESENT [Anthony Fu](https://github.com/antfu)
+[MIT](./LICENSE) License &copy; 2019-PRESENT [Wilfried AGO](https://github.com/wilfriedago)

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,8 +1,8 @@
 import styleMigrate from '@stylistic/eslint-plugin-migrate'
 
-import { antfu } from './src'
+import { thewlabs } from './src'
 
-export default antfu(
+export default thewlabs(
   {
     vue: {
       a11y: true,

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "@antfu/eslint-config",
+  "name": "eslint-config-thewlabs",
   "type": "module",
   "version": "4.11.0",
-  "packageManager": "pnpm@10.6.5",
-  "description": "Anthony's ESLint config",
-  "author": "Anthony Fu <anthonyfu117@hotmail.com> (https://github.com/antfu/)",
+  "packageManager": "pnpm@10.7.0+sha512.6b865ad4b62a1d9842b61d674a393903b871d9244954f652b8842c2b553c72176b278f64c463e52d40fff8aba385c235c8c9ecf5cc7de4fd78b8bb6d49633ab6",
+  "description": "thewlabs eslint config",
+  "author": "Wilfried AGO <me@wilfriedago.dev> (https://github.com/wilfriedago)",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/antfu",
-  "homepage": "https://github.com/antfu/eslint-config",
+  "funding": "https://github.com/sponsors/wilfriedago",
+  "homepage": "https://github.com/thewlabs/eslint-config-thewlabs#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/antfu/eslint-config.git"
+    "url": "git+https://github.com/thewlabs/eslint-config-thewlabs.git"
   },
   "bugs": {
-    "url": "https://github.com/antfu/eslint-config/issues"
+    "url": "https://github.com/thewlabs/eslint-config-thewlabs/issues"
   },
   "keywords": [
     "eslint-config"
@@ -142,7 +142,6 @@
     "yaml-eslint-parser": "catalog:prod"
   },
   "devDependencies": {
-    "@antfu/eslint-config": "workspace:*",
     "@antfu/ni": "catalog:dev",
     "@eslint-react/eslint-plugin": "catalog:peer",
     "@eslint/config-inspector": "catalog:dev",
@@ -153,6 +152,7 @@
     "astro-eslint-parser": "catalog:peer",
     "bumpp": "catalog:dev",
     "eslint": "catalog:peer",
+    "eslint-config-thewlabs": "workspace:*",
     "eslint-plugin-astro": "catalog:peer",
     "eslint-plugin-format": "catalog:peer",
     "eslint-plugin-react-hooks": "catalog:peer",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,9 +329,6 @@ importers:
         specifier: catalog:prod
         version: 1.3.0
     devDependencies:
-      '@antfu/eslint-config':
-        specifier: workspace:*
-        version: 'link:'
       '@antfu/ni':
         specifier: catalog:dev
         version: 24.3.0
@@ -362,6 +359,9 @@ importers:
       eslint:
         specifier: ^9.23.0
         version: 9.23.0(jiti@2.4.2)
+      eslint-config-thewlabs:
+        specifier: workspace:*
+        version: 'link:'
       eslint-plugin-astro:
         specifier: catalog:peer
         version: 1.3.1(eslint@9.23.0(jiti@2.4.2))

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,10 +9,10 @@ import { run } from './run'
 
 function header(): void {
   console.log('\n')
-  p.intro(`${c.green`@antfu/eslint-config `}${c.dim`v${version}`}`)
+  p.intro(`${c.green`eslint-config-thewlabs `}${c.dim`v${version}`}`)
 }
 
-const cli = cac('@antfu/eslint-config')
+const cli = cac('eslint-config-thewlabs')
 
 cli
   .command('', 'Run the initialization or migration')

--- a/src/cli/stages/update-package-json.ts
+++ b/src/cli/stages/update-package-json.ts
@@ -16,13 +16,13 @@ export async function updatePackageJson(result: PromptResult): Promise<void> {
 
   const pathPackageJSON = path.join(cwd, 'package.json')
 
-  p.log.step(c.cyan`Bumping @antfu/eslint-config to v${version}`)
+  p.log.step(c.cyan`Bumping eslint-plugin-thewlabs to v${version}`)
 
   const pkgContent = await fsp.readFile(pathPackageJSON, 'utf-8')
   const pkg: Record<string, any> = JSON.parse(pkgContent)
 
   pkg.devDependencies ??= {}
-  pkg.devDependencies['@antfu/eslint-config'] = `^${version}`
+  pkg.devDependencies['eslint-plugin-thewlabs'] = `^${version}`
   pkg.devDependencies.eslint ??= versionsMap.eslint
 
   const addedPackages: string[] = []

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -15,9 +15,9 @@ export function getEslintConfigContent(
   additionalConfigs?: string[],
 ): string {
   return `
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu({
+export default thewlabs({
 ${mainConfig}
 }${additionalConfigs?.map(config => `,{\n${config}\n}`)})
 `.trimStart()

--- a/src/configs/astro.ts
+++ b/src/configs/astro.ts
@@ -24,7 +24,7 @@ export async function astro(
 
   return [
     {
-      name: 'antfu/astro/setup',
+      name: 'thewlabs/astro/setup',
       plugins: {
         astro: pluginAstro,
       },
@@ -40,7 +40,7 @@ export async function astro(
         },
         sourceType: 'module',
       },
-      name: 'antfu/astro/rules',
+      name: 'thewlabs/astro/rules',
       processor: 'astro/client-side-ts',
       rules: {
         // Astro uses top level await for e.g. data fetching

--- a/src/configs/command.ts
+++ b/src/configs/command.ts
@@ -6,7 +6,7 @@ export async function command(): Promise<TypedFlatConfigItem[]> {
   return [
     {
       ...createCommand(),
-      name: 'antfu/command/rules',
+      name: 'thewlabs/command/rules',
     },
   ]
 }

--- a/src/configs/comments.ts
+++ b/src/configs/comments.ts
@@ -5,7 +5,7 @@ import { pluginComments } from '../plugins'
 export async function comments(): Promise<TypedFlatConfigItem[]> {
   return [
     {
-      name: 'antfu/eslint-comments/rules',
+      name: 'thewlabs/eslint-comments/rules',
       plugins: {
         'eslint-comments': pluginComments,
       },

--- a/src/configs/disables.ts
+++ b/src/configs/disables.ts
@@ -6,7 +6,7 @@ export async function disables(): Promise<TypedFlatConfigItem[]> {
   return [
     {
       files: [`**/scripts/${GLOB_SRC}`],
-      name: 'antfu/disables/scripts',
+      name: 'thewlabs/disables/scripts',
       rules: {
         'antfu/no-top-level-await': 'off',
         'no-console': 'off',
@@ -15,7 +15,7 @@ export async function disables(): Promise<TypedFlatConfigItem[]> {
     },
     {
       files: [`**/cli/${GLOB_SRC}`, `**/cli.${GLOB_SRC_EXT}`],
-      name: 'antfu/disables/cli',
+      name: 'thewlabs/disables/cli',
       rules: {
         'antfu/no-top-level-await': 'off',
         'no-console': 'off',
@@ -23,7 +23,7 @@ export async function disables(): Promise<TypedFlatConfigItem[]> {
     },
     {
       files: ['**/bin/**/*', `**/bin.${GLOB_SRC_EXT}`],
-      name: 'antfu/disables/bin',
+      name: 'thewlabs/disables/bin',
       rules: {
         'antfu/no-import-dist': 'off',
         'antfu/no-import-node-modules-by-path': 'off',
@@ -31,7 +31,7 @@ export async function disables(): Promise<TypedFlatConfigItem[]> {
     },
     {
       files: ['**/*.d.?([cm])ts'],
-      name: 'antfu/disables/dts',
+      name: 'thewlabs/disables/dts',
       rules: {
         'eslint-comments/no-unlimited-disable': 'off',
         'import/no-duplicates': 'off',
@@ -41,14 +41,14 @@ export async function disables(): Promise<TypedFlatConfigItem[]> {
     },
     {
       files: ['**/*.js', '**/*.cjs'],
-      name: 'antfu/disables/cjs',
+      name: 'thewlabs/disables/cjs',
       rules: {
         'ts/no-require-imports': 'off',
       },
     },
     {
       files: [`**/*.config.${GLOB_SRC_EXT}`, `**/*.config.*.${GLOB_SRC_EXT}`],
-      name: 'antfu/disables/config-files',
+      name: 'thewlabs/disables/config-files',
       rules: {
         'antfu/no-top-level-await': 'off',
         'no-console': 'off',

--- a/src/configs/ignores.ts
+++ b/src/configs/ignores.ts
@@ -9,7 +9,7 @@ export async function ignores(userIgnores: string[] = []): Promise<TypedFlatConf
         ...GLOB_EXCLUDE,
         ...userIgnores,
       ],
-      name: 'antfu/ignores',
+      name: 'thewlabs/ignores',
     },
   ]
 }

--- a/src/configs/imports.ts
+++ b/src/configs/imports.ts
@@ -9,7 +9,7 @@ export async function imports(options: OptionsStylistic = {}): Promise<TypedFlat
 
   return [
     {
-      name: 'antfu/imports/rules',
+      name: 'thewlabs/imports/rules',
       plugins: {
         antfu: pluginAntfu,
         import: pluginImport,

--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -36,10 +36,10 @@ export async function javascript(
       linterOptions: {
         reportUnusedDisableDirectives: true,
       },
-      name: 'antfu/javascript/setup',
+      name: 'thewlabs/javascript/setup',
     },
     {
-      name: 'antfu/javascript/rules',
+      name: 'thewlabs/javascript/rules',
       plugins: {
         'antfu': pluginAntfu,
         'unused-imports': pluginUnusedImports,

--- a/src/configs/jsdoc.ts
+++ b/src/configs/jsdoc.ts
@@ -12,7 +12,7 @@ export async function jsdoc(options: OptionsStylistic & OptionsFiles = {}): Prom
   return [
     {
       files,
-      name: 'antfu/jsdoc/rules',
+      name: 'thewlabs/jsdoc/rules',
       plugins: {
         jsdoc: await interopDefault(import('eslint-plugin-jsdoc')),
       },

--- a/src/configs/jsonc.ts
+++ b/src/configs/jsonc.ts
@@ -26,7 +26,7 @@ export async function jsonc(
 
   return [
     {
-      name: 'antfu/jsonc/setup',
+      name: 'thewlabs/jsonc/setup',
       plugins: {
         jsonc: pluginJsonc as any,
       },
@@ -36,7 +36,7 @@ export async function jsonc(
       languageOptions: {
         parser: parserJsonc,
       },
-      name: 'antfu/jsonc/rules',
+      name: 'thewlabs/jsonc/rules',
       rules: {
         'jsonc/no-bigint-literals': 'error',
         'jsonc/no-binary-expression': 'error',

--- a/src/configs/jsx.ts
+++ b/src/configs/jsx.ts
@@ -13,7 +13,7 @@ export async function jsx(): Promise<TypedFlatConfigItem[]> {
           },
         },
       },
-      name: 'antfu/jsx/setup',
+      name: 'thewlabs/jsx/setup',
     },
   ]
 }

--- a/src/configs/markdown.ts
+++ b/src/configs/markdown.ts
@@ -18,7 +18,7 @@ export async function markdown(
 
   return [
     {
-      name: 'antfu/markdown/setup',
+      name: 'thewlabs/markdown/setup',
       plugins: {
         markdown,
       },
@@ -26,7 +26,7 @@ export async function markdown(
     {
       files,
       ignores: [GLOB_MARKDOWN_IN_MARKDOWN],
-      name: 'antfu/markdown/processor',
+      name: 'thewlabs/markdown/processor',
       // `eslint-plugin-markdown` only creates virtual files for code blocks,
       // but not the markdown file itself. We use `eslint-merge-processors` to
       // add a pass-through processor for the markdown file itself.
@@ -40,7 +40,7 @@ export async function markdown(
       languageOptions: {
         parser: parserPlain,
       },
-      name: 'antfu/markdown/parser',
+      name: 'thewlabs/markdown/parser',
     },
     {
       files: [
@@ -54,7 +54,7 @@ export async function markdown(
           },
         },
       },
-      name: 'antfu/markdown/disables',
+      name: 'thewlabs/markdown/disables',
       rules: {
         'antfu/no-top-level-await': 'off',
 

--- a/src/configs/node.ts
+++ b/src/configs/node.ts
@@ -5,7 +5,7 @@ import { pluginNode } from '../plugins'
 export async function node(): Promise<TypedFlatConfigItem[]> {
   return [
     {
-      name: 'antfu/node/rules',
+      name: 'thewlabs/node/rules',
       plugins: {
         node: pluginNode,
       },

--- a/src/configs/perfectionist.ts
+++ b/src/configs/perfectionist.ts
@@ -10,7 +10,7 @@ import { pluginPerfectionist } from '../plugins'
 export async function perfectionist(): Promise<TypedFlatConfigItem[]> {
   return [
     {
-      name: 'antfu/perfectionist/setup',
+      name: 'thewlabs/perfectionist/setup',
       plugins: {
         perfectionist: pluginPerfectionist,
       },

--- a/src/configs/pnpm.ts
+++ b/src/configs/pnpm.ts
@@ -22,7 +22,7 @@ export async function pnpm(): Promise<TypedFlatConfigItem[]> {
       languageOptions: {
         parser: jsoncParser,
       },
-      name: 'antfu/pnpm/package-json',
+      name: 'thewlabs/pnpm/package-json',
       plugins: {
         pnpm: pluginPnpm,
       },
@@ -37,7 +37,7 @@ export async function pnpm(): Promise<TypedFlatConfigItem[]> {
       languageOptions: {
         parser: yamlParser,
       },
-      name: 'antfu/pnpm/pnpm-workspace-yaml',
+      name: 'thewlabs/pnpm/pnpm-workspace-yaml',
       plugins: {
         pnpm: pluginPnpm,
       },

--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -71,7 +71,7 @@ export async function react(
 
   return [
     {
-      name: 'antfu/react/setup',
+      name: 'thewlabs/react/setup',
       plugins: {
         'react': plugins['@eslint-react'],
         'react-dom': plugins['@eslint-react/dom'],
@@ -92,7 +92,7 @@ export async function react(
         },
         sourceType: 'module',
       },
-      name: 'antfu/react/rules',
+      name: 'thewlabs/react/rules',
       rules: {
         // recommended rules from eslint-plugin-react-x https://eslint-react.xyz/docs/rules/overview#core-rules
         'react/no-access-state-in-setstate': 'error',
@@ -209,7 +209,7 @@ export async function react(
       ? [{
           files: filesTypeAware,
           ignores: ignoresTypeAware,
-          name: 'antfu/react/type-aware-rules',
+          name: 'thewlabs/react/type-aware-rules',
           rules: {
             ...typeAwareRules,
           },

--- a/src/configs/regexp.ts
+++ b/src/configs/regexp.ts
@@ -21,7 +21,7 @@ export async function regexp(
   return [
     {
       ...config,
-      name: 'antfu/regexp/rules',
+      name: 'thewlabs/regexp/rules',
       rules: {
         ...rules,
         ...options.overrides,

--- a/src/configs/solid.ts
+++ b/src/configs/solid.ts
@@ -31,7 +31,7 @@ export async function solid(
 
   return [
     {
-      name: 'antfu/solid/setup',
+      name: 'thewlabs/solid/setup',
       plugins: {
         solid: pluginSolid,
       },
@@ -48,7 +48,7 @@ export async function solid(
         },
         sourceType: 'module',
       },
-      name: 'antfu/solid/rules',
+      name: 'thewlabs/solid/rules',
       rules: {
         // reactivity
         'solid/components-return-once': 'warn',

--- a/src/configs/sort.ts
+++ b/src/configs/sort.ts
@@ -9,7 +9,7 @@ export async function sortPackageJson(): Promise<TypedFlatConfigItem[]> {
   return [
     {
       files: ['**/package.json'],
-      name: 'antfu/sort/package-json',
+      name: 'thewlabs/sort/package-json',
       rules: {
         'jsonc/sort-array-values': [
           'error',
@@ -117,7 +117,7 @@ export function sortTsconfig(): TypedFlatConfigItem[] {
   return [
     {
       files: ['**/tsconfig.json', '**/tsconfig.*.json'],
-      name: 'antfu/sort/tsconfig-json',
+      name: 'thewlabs/sort/tsconfig-json',
       rules: {
         'jsonc/sort-keys': [
           'error',

--- a/src/configs/stylistic.ts
+++ b/src/configs/stylistic.ts
@@ -41,7 +41,7 @@ export async function stylistic(
 
   return [
     {
-      name: 'antfu/stylistic/rules',
+      name: 'thewlabs/stylistic/rules',
       plugins: {
         antfu: pluginAntfu,
         style: pluginStylistic,

--- a/src/configs/svelte.ts
+++ b/src/configs/svelte.ts
@@ -31,7 +31,7 @@ export async function svelte(
 
   return [
     {
-      name: 'antfu/svelte/setup',
+      name: 'thewlabs/svelte/setup',
       plugins: {
         svelte: pluginSvelte,
       },
@@ -47,7 +47,7 @@ export async function svelte(
             : null,
         },
       },
-      name: 'antfu/svelte/rules',
+      name: 'thewlabs/svelte/rules',
       processor: pluginSvelte.processors['.svelte'],
       rules: {
         'import/no-mutable-exports': 'off',

--- a/src/configs/test.ts
+++ b/src/configs/test.ts
@@ -35,14 +35,14 @@ export async function test(
 
   return [
     {
-      name: 'antfu/test/setup',
+      name: 'thewlabs/test/setup',
       plugins: {
         test: _pluginTest,
       },
     },
     {
       files,
-      name: 'antfu/test/rules',
+      name: 'thewlabs/test/rules',
       rules: {
         'test/consistent-test-it': ['error', { fn: 'it', withinDescribe: 'it' }],
         'test/no-identical-title': 'error',

--- a/src/configs/toml.ts
+++ b/src/configs/toml.ts
@@ -26,7 +26,7 @@ export async function toml(
 
   return [
     {
-      name: 'antfu/toml/setup',
+      name: 'thewlabs/toml/setup',
       plugins: {
         toml: pluginToml,
       },
@@ -36,7 +36,7 @@ export async function toml(
       languageOptions: {
         parser: parserToml,
       },
-      name: 'antfu/toml/rules',
+      name: 'thewlabs/toml/rules',
       rules: {
         'style/spaced-comment': 'off',
 

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -93,14 +93,14 @@ export async function typescript(
           ...parserOptions as any,
         },
       },
-      name: `antfu/typescript/${typeAware ? 'type-aware-parser' : 'parser'}`,
+      name: `thewlabs/typescript/${typeAware ? 'type-aware-parser' : 'parser'}`,
     }
   }
 
   return [
     {
       // Install the plugins without globs, so they can be configured separately.
-      name: 'antfu/typescript/setup',
+      name: 'thewlabs/typescript/setup',
       plugins: {
         antfu: pluginAntfu,
         ts: pluginTs as any,
@@ -117,7 +117,7 @@ export async function typescript(
         ],
     {
       files,
-      name: 'antfu/typescript/rules',
+      name: 'thewlabs/typescript/rules',
       rules: {
         ...renameRules(
           pluginTs.configs['eslint-recommended'].overrides![0].rules!,
@@ -179,7 +179,7 @@ export async function typescript(
       ? [{
           files: filesTypeAware,
           ignores: ignoresTypeAware,
-          name: 'antfu/typescript/rules-type-aware',
+          name: 'thewlabs/typescript/rules-type-aware',
           rules: {
             ...typeAwareRules,
             ...overridesTypeAware,

--- a/src/configs/unicorn.ts
+++ b/src/configs/unicorn.ts
@@ -5,7 +5,7 @@ import { pluginUnicorn } from '../plugins'
 export async function unicorn(options: OptionsUnicorn = {}): Promise<TypedFlatConfigItem[]> {
   return [
     {
-      name: 'antfu/unicorn/rules',
+      name: 'thewlabs/unicorn/rules',
       plugins: {
         unicorn: pluginUnicorn,
       },

--- a/src/configs/unocss.ts
+++ b/src/configs/unocss.ts
@@ -22,7 +22,7 @@ export async function unocss(
 
   return [
     {
-      name: 'antfu/unocss',
+      name: 'thewlabs/unocss',
       plugins: {
         unocss: pluginUnoCSS,
       },

--- a/src/configs/vue.ts
+++ b/src/configs/vue.ts
@@ -70,7 +70,7 @@ export async function vue(
           watchEffect: 'readonly',
         },
       },
-      name: 'antfu/vue/setup',
+      name: 'thewlabs/vue/setup',
       plugins: {
         vue: pluginVue,
         ...a11y ? { 'vue-a11y': pluginVueA11y } : {},
@@ -91,7 +91,7 @@ export async function vue(
           sourceType: 'module',
         },
       },
-      name: 'antfu/vue/rules',
+      name: 'thewlabs/vue/rules',
       processor: sfcBlocks === false
         ? pluginVue.processors['.vue']
         : mergeProcessors([

--- a/src/configs/yaml.ts
+++ b/src/configs/yaml.ts
@@ -27,7 +27,7 @@ export async function yaml(
 
   return [
     {
-      name: 'antfu/yaml/setup',
+      name: 'thewlabs/yaml/setup',
       plugins: {
         yaml: pluginYaml,
       },
@@ -37,7 +37,7 @@ export async function yaml(
       languageOptions: {
         parser: parserYaml,
       },
-      name: 'antfu/yaml/rules',
+      name: 'thewlabs/yaml/rules',
       rules: {
         'style/spaced-comment': 'off',
 
@@ -71,7 +71,7 @@ export async function yaml(
     },
     {
       files: ['pnpm-workspace.yaml'],
-      name: 'antfu/yaml/pnpm-workspace',
+      name: 'thewlabs/yaml/pnpm-workspace',
       rules: {
         'yaml/sort-keys': [
           'error',

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -78,7 +78,7 @@ export const defaultPluginRenaming = {
  * @returns {Promise<TypedFlatConfigItem[]>}
  *  The merged ESLint configurations.
  */
-export function antfu(
+export function thewlabs(
   options: OptionsConfig & Omit<TypedFlatConfigItem, 'files'> = {},
   ...userConfigs: Awaitable<TypedFlatConfigItem | TypedFlatConfigItem[] | FlatConfigComposer<any, any> | Linter.Config[]>[]
 ): FlatConfigComposer<TypedFlatConfigItem, ConfigNames> {
@@ -104,7 +104,7 @@ export function antfu(
     isInEditor = isInEditorEnv()
     if (isInEditor)
       // eslint-disable-next-line no-console
-      console.log('[@antfu/eslint-config] Detected running in editor, some rules are disabled.')
+      console.log('[eslint-config-thewlabs] Detected running in editor, some rules are disabled.')
   }
 
   const stylisticOptions = options.stylistic === false
@@ -121,13 +121,13 @@ export function antfu(
   if (enableGitignore) {
     if (typeof enableGitignore !== 'boolean') {
       configs.push(interopDefault(import('eslint-config-flat-gitignore')).then(r => [r({
-        name: 'antfu/gitignore',
+        name: 'thewlabs/gitignore',
         ...enableGitignore,
       })]))
     }
     else {
       configs.push(interopDefault(import('eslint-config-flat-gitignore')).then(r => [r({
-        name: 'antfu/gitignore',
+        name: 'thewlabs/gitignore',
         strict: false,
       })]))
     }
@@ -298,7 +298,7 @@ export function antfu(
   )
 
   if ('files' in options) {
-    throw new Error('[@antfu/eslint-config] The first argument should not contain the "files" property as the options are supposed to be global. Place it in the second or later config instead.')
+    throw new Error('[eslint-config-thewlabs] The first argument should not contain the "files" property as the options are supposed to be global. Place it in the second or later config instead.')
   }
 
   // User can optionally pass a flat config item to the first argument

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { antfu } from './factory'
+import { thewlabs } from './factory'
 
 export * from './configs'
 export * from './factory'
@@ -6,4 +6,4 @@ export * from './globs'
 export * from './types'
 export * from './utils'
 
-export default antfu
+export default thewlabs

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url'
 import { isPackageExists } from 'local-pkg'
 
 const scopeUrl = fileURLToPath(new URL('.', import.meta.url))
-const isCwdInScope = isPackageExists('@antfu/eslint-config')
+const isCwdInScope = isPackageExists('eslint-config-thewlabs')
 
 export const parserPlain = {
   meta: {
@@ -42,7 +42,7 @@ export async function combine(...configs: Awaitable<TypedFlatConfigItem | TypedF
  *
  * @example
  * ```ts
- * import { renameRules } from '@antfu/eslint-config'
+ * import { renameRules } from 'eslint-config-thewlabs'
  *
  * export default [{
  *   rules: renameRules(
@@ -75,7 +75,7 @@ export function renameRules(
  *
  * @example
  * ```ts
- * import { renamePluginInConfigs } from '@antfu/eslint-config'
+ * import { renamePluginInConfigs } from 'eslint-config-thewlabs'
  * import someConfigs from './some-configs'
  *
  * export default renamePluginInConfigs(someConfigs, {

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -46,7 +46,7 @@ it('package.json updated', async () => {
 
   const pkgContent: Record<string, any> = JSON.parse(await fs.readFile(join(genPath, 'package.json'), 'utf-8'))
 
-  expect(JSON.stringify(pkgContent.devDependencies)).toContain('@antfu/eslint-config')
+  expect(JSON.stringify(pkgContent.devDependencies)).toContain('eslint-plugin-thewlabs')
   expect(stdout).toContain('Changes wrote to package.json')
 })
 
@@ -69,9 +69,9 @@ it('ignores files added in eslint.config.js', async () => {
   expect(stdout).toContain('Created eslint.config.mjs')
   expect(eslintConfigContent)
     .toMatchInlineSnapshot(`
-      "import antfu from '@antfu/eslint-config'
+      "import thewlabs from 'eslint-config-thewlabs'
 
-      export default antfu({
+      export default thewlabs({
         ignores: ["some-path","**/some-path/**","some-file","**/some-file/**"],
       })
       "

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -126,9 +126,9 @@ function runWithConfig(name: string, configs: OptionsConfig, ...items: TypedFlat
     })
     await fs.writeFile(join(target, 'eslint.config.js'), `
 // @eslint-disable
-import antfu from '@antfu/eslint-config'
+import thewlabs from 'eslint-config-thewlabs'
 
-export default antfu(
+export default thewlabs(
   ${JSON.stringify(configs)},
   ...${JSON.stringify(items) ?? []},
 )


### PR DESCRIPTION
This pull request includes changes to update the project ownership and rebrand the ESLint configuration package. The most important changes involve updating the author information in the `LICENSE` file and modifying the `README.md` file to reflect the new package name and associated links.

Rebranding and ownership updates:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated the copyright information to reflect the new owner, Wilfried AGO.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R10): Changed the package name from `@antfu/eslint-config` to `eslint-config-thewlabs` and updated all related links and references. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R55) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R72) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L258-R273) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L302-R310) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L352-R352) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L374-R374) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L383-R392) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L417-R421) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L436-R440) [[12]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L463-R467) [[13]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L486-R500) [[14]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L519-R523) [[15]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L532-R536) [[16]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L549-R553) [[17]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L570-R578) [[18]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L610-R614) [[19]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L629-R633) [[20]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L648-R652) [[21]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L667-R671) [[22]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L686-R690) [[23]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L705-R707) [[24]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L714-R716) [[25]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L743-R747) [[26]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L760-R770) [[27]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L829-R840)