### PR TITLE
feat: introduces support for Angular and Angular templates

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -7,6 +7,8 @@ export default thewlabs(
     vue: {
       a11y: true,
     },
+    angular: true,
+    angularTemplate: true,
     react: true,
     solid: true,
     svelte: true,

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "prepare": "simple-git-hooks"
   },
   "peerDependencies": {
+    "@angular-eslint/eslint-plugin": "^19.3.0",
+    "@angular-eslint/eslint-plugin-template": "^19.3.0",
+    "@angular-eslint/template-parser": "^19.3.0",
     "@eslint-react/eslint-plugin": "^1.19.0",
     "@prettier/plugin-xml": "^3.4.1",
     "@unocss/eslint-plugin": ">=0.50.0",
@@ -142,6 +145,10 @@
     "yaml-eslint-parser": "catalog:prod"
   },
   "devDependencies": {
+    "@angular-eslint/eslint-plugin": "catalog:peer",
+    "@angular-eslint/eslint-plugin-template": "catalog:peer",
+    "@angular-eslint/template-parser": "catalog:peer",
+    "@antfu/eslint-config": "workspace:*",
     "@antfu/ni": "catalog:dev",
     "@eslint-react/eslint-plugin": "catalog:peer",
     "@eslint/config-inspector": "catalog:dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,15 @@ catalogs:
       specifier: ^3.0.9
       version: 3.0.9
   peer:
+    '@angular-eslint/eslint-plugin':
+      specifier: ^19.3.0
+      version: 19.3.0
+    '@angular-eslint/eslint-plugin-template':
+      specifier: ^19.3.0
+      version: 19.3.0
+    '@angular-eslint/template-parser':
+      specifier: ^19.3.0
+      version: 19.3.0
     '@eslint-react/eslint-plugin':
       specifier: ^1.37.3
       version: 1.37.3
@@ -329,6 +338,18 @@ importers:
         specifier: catalog:prod
         version: 1.3.0
     devDependencies:
+      '@angular-eslint/eslint-plugin':
+        specifier: catalog:peer
+        version: 19.3.0(@typescript-eslint/utils@8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      '@angular-eslint/eslint-plugin-template':
+        specifier: catalog:peer
+        version: 19.3.0(@typescript-eslint/types@8.27.0)(@typescript-eslint/utils@8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      '@angular-eslint/template-parser':
+        specifier: catalog:peer
+        version: 19.3.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      '@antfu/eslint-config':
+        specifier: workspace:*
+        version: 'link:'
       '@antfu/ni':
         specifier: catalog:dev
         version: 24.3.0
@@ -437,6 +458,37 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@angular-eslint/bundled-angular-compiler@19.3.0':
+    resolution: {integrity: sha512-63Zci4pvnUR1iSkikFlNbShF1tO5HOarYd8fvNfmOZwFfZ/1T3j3bCy9YbE+aM5SYrWqPaPP/OcwZ3wJ8WNvqA==}
+
+  '@angular-eslint/eslint-plugin-template@19.3.0':
+    resolution: {integrity: sha512-WyouppTpOYut+wvv13wlqqZ8EHoDrCZxNfGKuEUYK1BPmQlTB8EIZfQH4iR1rFVS28Rw+XRIiXo1x3oC0SOfnA==}
+    peerDependencies:
+      '@typescript-eslint/types': ^7.11.0 || ^8.0.0
+      '@typescript-eslint/utils': ^8.27.0
+      eslint: ^9.23.0
+      typescript: '*'
+
+  '@angular-eslint/eslint-plugin@19.3.0':
+    resolution: {integrity: sha512-nBLslLI20KnVbqlfNW7GcnI9R6cYCvRGjOE2QYhzxM316ciAQ62tvQuXP9ZVnRBLSKDAVnMeC0eTq9O4ysrxrQ==}
+    peerDependencies:
+      '@typescript-eslint/utils': ^8.27.0
+      eslint: ^9.23.0
+      typescript: '*'
+
+  '@angular-eslint/template-parser@19.3.0':
+    resolution: {integrity: sha512-VxMNgsHXMWbbmZeBuBX5i8pzsSSEaoACVpaE+j8Muk60Am4Mxc0PytJm4n3znBSvI3B7Kq2+vStSRYPkOER4lA==}
+    peerDependencies:
+      eslint: ^9.23.0
+      typescript: '*'
+
+  '@angular-eslint/utils@19.3.0':
+    resolution: {integrity: sha512-ovvbQh96FIJfepHqLCMdKFkPXr3EbcvYc9kMj9hZyIxs/9/VxwPH7x25mMs4VsL6rXVgH2FgG5kR38UZlcTNNw==}
+    peerDependencies:
+      '@typescript-eslint/utils': ^8.27.0
+      eslint: ^9.23.0
+      typescript: '*'
 
   '@antfu/install-pkg@1.0.0':
     resolution: {integrity: sha512-xvX6P/lo1B3ej0OsaErAjqgFYzYVcJpamjLAFLYh9vRJngBrMoUG7aVnrGTeqM7yxbyTD5p3F2+0/QUEh8Vzhw==}
@@ -3425,6 +3477,41 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
+
+  '@angular-eslint/bundled-angular-compiler@19.3.0': {}
+
+  '@angular-eslint/eslint-plugin-template@19.3.0(@typescript-eslint/types@8.27.0)(@typescript-eslint/utils@8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)':
+    dependencies:
+      '@angular-eslint/bundled-angular-compiler': 19.3.0
+      '@angular-eslint/utils': 19.3.0(@typescript-eslint/utils@8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/types': 8.27.0
+      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      eslint: 9.23.0(jiti@2.4.2)
+      typescript: 5.8.2
+
+  '@angular-eslint/eslint-plugin@19.3.0(@typescript-eslint/utils@8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)':
+    dependencies:
+      '@angular-eslint/bundled-angular-compiler': 19.3.0
+      '@angular-eslint/utils': 19.3.0(@typescript-eslint/utils@8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      eslint: 9.23.0(jiti@2.4.2)
+      typescript: 5.8.2
+
+  '@angular-eslint/template-parser@19.3.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)':
+    dependencies:
+      '@angular-eslint/bundled-angular-compiler': 19.3.0
+      eslint: 9.23.0(jiti@2.4.2)
+      eslint-scope: 8.3.0
+      typescript: 5.8.2
+
+  '@angular-eslint/utils@19.3.0(@typescript-eslint/utils@8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)':
+    dependencies:
+      '@angular-eslint/bundled-angular-compiler': 19.3.0
+      '@typescript-eslint/utils': 8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      eslint: 9.23.0(jiti@2.4.2)
+      typescript: 5.8.2
 
   '@antfu/install-pkg@1.0.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,9 @@ catalogs:
     typescript: ^5.8.2
     vitest: ^3.0.9
   peer:
+    '@angular-eslint/eslint-plugin': ^19.3.0
+    '@angular-eslint/eslint-plugin-template': ^19.3.0
+    '@angular-eslint/template-parser': ^19.3.0
     '@eslint-react/eslint-plugin': ^1.37.3
     '@prettier/plugin-xml': ^3.4.1
     '@unocss/eslint-plugin': ^66.0.0

--- a/scripts/typegen.ts
+++ b/scripts/typegen.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises'
 import { flatConfigsToRulesDTS } from 'eslint-typegen/core'
 import { builtinRules } from 'eslint/use-at-your-own-risk'
 
-import { astro, combine, comments, formatters, imports, javascript, jsdoc, jsonc, jsx, markdown, node, perfectionist, react, regexp, solid, sortPackageJson, stylistic, svelte, test, toml, typescript, unicorn, unocss, vue, yaml } from '../src'
+import { angular, angularTemplate, astro, combine, comments, formatters, imports, javascript, jsdoc, jsonc, jsx, markdown, node, perfectionist, react, regexp, solid, sortPackageJson, stylistic, svelte, test, toml, typescript, unicorn, unocss, vue, yaml } from '../src'
 
 const configs = await combine(
   {
@@ -13,6 +13,8 @@ const configs = await combine(
       },
     },
   },
+  angular(),
+  angularTemplate(),
   astro(),
   comments(),
   formatters(),

--- a/src/configs/angular-template.ts
+++ b/src/configs/angular-template.ts
@@ -1,0 +1,78 @@
+import type { OptionsFiles, OptionsOverrides, TypedFlatConfigItem } from 'src/types'
+
+import { GLOB_HTML } from '../globs'
+import { ensurePackages, interopDefault } from '../utils'
+
+export async function angularTemplate(
+  options: OptionsOverrides & OptionsFiles = {},
+): Promise<TypedFlatConfigItem[]> {
+  const {
+    files = [GLOB_HTML],
+    overrides = {},
+  } = options
+
+  await ensurePackages([
+    '@angular-eslint/eslint-plugin-template',
+  ])
+
+  const [
+    pluginAngularTemplate,
+    parserAngularTemplate,
+  ] = await Promise.all([
+    interopDefault(import('@angular-eslint/eslint-plugin-template')),
+    interopDefault(import('@angular-eslint/template-parser')),
+  ] as const)
+
+  return [
+    {
+      name: 'thewlabs/angular/template/setup',
+      plugins: {
+        'angular/template': pluginAngularTemplate,
+      },
+    },
+    {
+      files,
+      languageOptions: {
+        parser: parserAngularTemplate,
+        sourceType: 'module',
+      },
+      name: 'thewlabs/angular/template/rules',
+      rules: {
+        'angular/template/alt-text': 'error',
+        'angular/template/attributes-order': 'error',
+        'angular/template/banana-in-box': 'error',
+        'angular/template/button-has-type': 'error',
+        'angular/template/click-events-have-key-events': 'error',
+        'angular/template/conditional-complexity': 'error',
+        'angular/template/cyclomatic-complexity': 'error',
+        'angular/template/elements-content': 'error',
+        'angular/template/eqeqeq': 'error',
+        'angular/template/i18n': 'error',
+        'angular/template/interactive-supports-focus': 'error',
+        'angular/template/label-has-associated-control': 'error',
+        'angular/template/mouse-events-have-key-events': 'error',
+        'angular/template/no-any': 'error',
+        'angular/template/no-autofocus': 'error',
+        'angular/template/no-call-expression': 'error',
+        'angular/template/no-distracting-elements': 'error',
+        'angular/template/no-duplicate-attributes': 'error',
+        'angular/template/no-inline-styles': 'error',
+        'angular/template/no-interpolation-in-attributes': 'error',
+        'angular/template/no-negated-async': 'error',
+        'angular/template/no-positive-tabindex': 'error',
+        'angular/template/prefer-contextual-for-variables': 'error',
+        'angular/template/prefer-control-flow': 'error',
+        'angular/template/prefer-ngsrc': 'error',
+        'angular/template/prefer-self-closing-tags': 'error',
+        'angular/template/prefer-static-string-properties': 'error',
+        'angular/template/role-has-required-aria': 'error',
+        'angular/template/table-scope': 'error',
+        'angular/template/use-track-by-function': 'error',
+        'angular/template/valid-aria': 'error',
+
+        // overrides
+        ...overrides,
+      },
+    },
+  ]
+}

--- a/src/configs/angular.ts
+++ b/src/configs/angular.ts
@@ -1,0 +1,93 @@
+import type { OptionsFiles, OptionsHasTypeScript, OptionsOverrides, OptionsTypeScriptWithTypes, TypedFlatConfigItem } from 'src/types'
+import { GLOB_TS } from '../globs'
+import { ensurePackages, interopDefault, toArray } from '../utils'
+
+export async function angular(
+  options: OptionsHasTypeScript & OptionsOverrides & OptionsFiles & OptionsTypeScriptWithTypes = {},
+): Promise<TypedFlatConfigItem[]> {
+  const {
+    files = [GLOB_TS],
+    overrides = {},
+  } = options
+
+  await ensurePackages([
+    '@angular-eslint/eslint-plugin',
+  ])
+
+  const tsconfigPath = options?.tsconfigPath
+    ? toArray(options.tsconfigPath)
+    : undefined
+  const isTypeAware = !!tsconfigPath
+
+  const [
+    pluginAngular,
+    parserTs,
+  ] = await Promise.all([
+    interopDefault(import('@angular-eslint/eslint-plugin')),
+    interopDefault(import('@typescript-eslint/parser')),
+  ] as const)
+
+  return [
+    {
+      name: 'thewlabs/angular/setup',
+      plugins: {
+        angular: pluginAngular,
+      },
+    },
+    {
+      files,
+      languageOptions: {
+        parser: parserTs,
+        parserOptions: {
+          ...isTypeAware ? { project: tsconfigPath } : {},
+        },
+        sourceType: 'module',
+      },
+      name: 'thewlabs/angular/rules',
+      rules: {
+        'angular/component-class-suffix': 'error',
+        'angular/component-max-inline-declarations': 'error',
+        'angular/component-selector': 'error',
+        'angular/consistent-component-styles': 'error',
+        'angular/contextual-decorator': 'error',
+        'angular/contextual-lifecycle': 'error',
+        'angular/directive-class-suffix': 'error',
+        'angular/directive-selector': 'error',
+        'angular/no-async-lifecycle-method': 'error',
+        'angular/no-attribute-decorator': 'error',
+        'angular/no-conflicting-lifecycle': 'error',
+        'angular/no-duplicates-in-metadata-arrays': 'error',
+        'angular/no-empty-lifecycle-method': 'error',
+        'angular/no-forward-ref': 'error',
+        'angular/no-input-prefix': 'error',
+        'angular/no-input-rename': 'error',
+        'angular/no-inputs-metadata-property': 'error',
+        'angular/no-lifecycle-call': 'error',
+        'angular/no-output-native': 'error',
+        'angular/no-output-on-prefix': 'error',
+        'angular/no-output-rename': 'error',
+        'angular/no-outputs-metadata-property': 'error',
+        'angular/no-pipe-impure': 'error',
+        'angular/no-queries-metadata-property': 'error',
+        'angular/pipe-prefix': 'error',
+        'angular/prefer-on-push-component-change-detection': 'error',
+        'angular/prefer-output-readonly': 'error',
+        'angular/prefer-signals': 'error',
+        'angular/prefer-standalone': 'error',
+        'angular/relative-url-prefix': 'error',
+        'angular/require-lifecycle-on-prototype': 'error',
+        'angular/require-localize-metadata': 'error',
+        'angular/runtime-localize': 'error',
+        'angular/sort-lifecycle-methods': 'error',
+        'angular/use-component-selector': 'error',
+        'angular/use-component-view-encapsulation': 'error',
+        'angular/use-injectable-provided-in': 'error',
+        'angular/use-lifecycle-interface': 'error',
+        'angular/use-pipe-transform-interface': 'error',
+
+        // overrides
+        ...overrides,
+      },
+    },
+  ]
+}

--- a/src/configs/formatters.ts
+++ b/src/configs/formatters.ts
@@ -91,7 +91,7 @@ export async function formatters(
 
   const configs: TypedFlatConfigItem[] = [
     {
-      name: 'antfu/formatter/setup',
+      name: 'thewlabs/formatter/setup',
       plugins: {
         format: pluginFormat,
       },
@@ -105,7 +105,7 @@ export async function formatters(
         languageOptions: {
           parser: parserPlain,
         },
-        name: 'antfu/formatter/css',
+        name: 'thewlabs/formatter/css',
         rules: {
           'format/prettier': [
             'error',
@@ -120,7 +120,7 @@ export async function formatters(
         languageOptions: {
           parser: parserPlain,
         },
-        name: 'antfu/formatter/scss',
+        name: 'thewlabs/formatter/scss',
         rules: {
           'format/prettier': [
             'error',
@@ -135,7 +135,7 @@ export async function formatters(
         languageOptions: {
           parser: parserPlain,
         },
-        name: 'antfu/formatter/less',
+        name: 'thewlabs/formatter/less',
         rules: {
           'format/prettier': [
             'error',
@@ -154,7 +154,7 @@ export async function formatters(
       languageOptions: {
         parser: parserPlain,
       },
-      name: 'antfu/formatter/html',
+      name: 'thewlabs/formatter/html',
       rules: {
         'format/prettier': [
           'error',
@@ -172,7 +172,7 @@ export async function formatters(
       languageOptions: {
         parser: parserPlain,
       },
-      name: 'antfu/formatter/xml',
+      name: 'thewlabs/formatter/xml',
       rules: {
         'format/prettier': [
           'error',
@@ -186,13 +186,14 @@ export async function formatters(
       },
     })
   }
+
   if (options.svg) {
     configs.push({
       files: [GLOB_SVG],
       languageOptions: {
         parser: parserPlain,
       },
-      name: 'antfu/formatter/svg',
+      name: 'thewlabs/formatter/svg',
       rules: {
         'format/prettier': [
           'error',
@@ -224,7 +225,7 @@ export async function formatters(
       languageOptions: {
         parser: parserPlain,
       },
-      name: 'antfu/formatter/markdown',
+      name: 'thewlabs/formatter/markdown',
       rules: {
         [`format/${formater}`]: [
           'error',
@@ -247,7 +248,7 @@ export async function formatters(
         languageOptions: {
           parser: parserPlain,
         },
-        name: 'antfu/formatter/slidev',
+        name: 'thewlabs/formatter/slidev',
         rules: {
           'format/prettier': [
             'error',
@@ -270,7 +271,7 @@ export async function formatters(
       languageOptions: {
         parser: parserPlain,
       },
-      name: 'antfu/formatter/astro',
+      name: 'thewlabs/formatter/astro',
       rules: {
         'format/prettier': [
           'error',
@@ -286,7 +287,7 @@ export async function formatters(
 
     configs.push({
       files: [GLOB_ASTRO, GLOB_ASTRO_TS],
-      name: 'antfu/formatter/astro/disables',
+      name: 'thewlabs/formatter/astro/disables',
       rules: {
         'style/arrow-parens': 'off',
         'style/block-spacing': 'off',
@@ -305,7 +306,7 @@ export async function formatters(
       languageOptions: {
         parser: parserPlain,
       },
-      name: 'antfu/formatter/graphql',
+      name: 'thewlabs/formatter/graphql',
       rules: {
         'format/prettier': [
           'error',

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,3 +1,5 @@
+export * from './angular'
+export * from './angular-template'
 export * from './astro'
 export * from './command'
 export * from './comments'

--- a/src/configs/svelte.ts
+++ b/src/configs/svelte.ts
@@ -66,7 +66,6 @@ export async function svelte(
         'svelte/no-dupe-else-if-blocks': 'error',
         'svelte/no-dupe-style-properties': 'error',
         'svelte/no-dupe-use-directives': 'error',
-        'svelte/no-dynamic-slot-name': 'error',
         'svelte/no-export-load-in-svelte-module-in-kit-pages': 'error',
         'svelte/no-inner-declarations': 'error',
         'svelte/no-not-function-handler': 'error',

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -5,6 +5,8 @@ import type { Awaitable, ConfigNames, OptionsConfig, TypedFlatConfigItem } from 
 import { FlatConfigComposer } from 'eslint-flat-config-utils'
 import { isPackageExists } from 'local-pkg'
 import {
+  angular,
+  angularTemplate,
   astro,
   command,
   comments,
@@ -55,6 +57,9 @@ const VuePackages = [
 ]
 
 export const defaultPluginRenaming = {
+  '@angular-eslint/eslint-plugin': 'angular',
+  '@angular-eslint/eslint-plugin-template': 'angular/template',
+
   '@eslint-react': 'react',
   '@eslint-react/dom': 'react-dom',
   '@eslint-react/hooks-extra': 'react-hooks-extra',
@@ -83,6 +88,8 @@ export function thewlabs(
   ...userConfigs: Awaitable<TypedFlatConfigItem | TypedFlatConfigItem[] | FlatConfigComposer<any, any> | Linter.Config[]>[]
 ): FlatConfigComposer<TypedFlatConfigItem, ConfigNames> {
   const {
+    angular: enableAngular = false,
+    angularTemplate: enableAngularTemplate = false,
     astro: enableAstro = false,
     autoRenamePlugins = true,
     componentExts = [],
@@ -203,6 +210,20 @@ export function thewlabs(
       overrides: getOverrides(options, 'vue'),
       stylistic: stylisticOptions,
       typescript: !!enableTypeScript,
+    }))
+  }
+
+  if (enableAngular) {
+    configs.push(angular({
+      ...typescriptOptions,
+      overrides: getOverrides(options, 'angular'),
+      tsconfigPath,
+    }))
+  }
+
+  if (enableAngularTemplate) {
+    configs.push(angularTemplate({
+      overrides: getOverrides(options, 'angularTemplate'),
     }))
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -358,6 +358,26 @@ export interface OptionsConfig extends OptionsComponentExts, OptionsProjectType 
   regexp?: boolean | (OptionsRegExp & OptionsOverrides)
 
   /**
+   * Enable angular rules.
+   *
+   * Requires installing:
+   * - `@angular-eslint/eslint-plugin`
+   *
+   * @default false
+   */
+  angular?: boolean | OptionsOverrides
+
+  /**
+   * Enable angular template rules.
+   *
+   * Requires installing:
+   * - `@angular-eslint/eslint-plugin-template`
+   *
+   * @default false
+   */
+  angularTemplate?: boolean | OptionsOverrides
+
+  /**
    * Enable react rules.
    *
    * Requires installing:
@@ -452,5 +472,7 @@ export interface OptionsConfig extends OptionsComponentExts, OptionsProjectType 
     toml?: TypedFlatConfigItem['rules']
     react?: TypedFlatConfigItem['rules']
     svelte?: TypedFlatConfigItem['rules']
+    angular?: TypedFlatConfigItem['rules']
+    angularTemplate?: TypedFlatConfigItem['rules']
   }
 }


### PR DESCRIPTION
This pull request includes updates to add Angular support and rebrand configurations from `antfu` to `thewlabs`. The most important changes include enabling Angular support in various configuration files, adding new Angular-related configuration files, and updating the naming convention for formatter configurations.

### Angular Support:
* [`eslint.config.ts`](diffhunk://#diff-3202509a51dddde1968b20a04dfcedc90615eb6681cca0cda5f43a418a516857R10-R11): Added `angular` and `angularTemplate` support.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R46-R48): Added Angular ESLint plugins and template parser to `peerDependencies` and `devDependencies`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R46-R48) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R148-R151)
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR55-R63): Updated to include Angular ESLint plugins and template parser in `peer`, `importers`, `packages`, and `snapshots` sections. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR55-R63) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR341-R352) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR462-R492) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3481-R3515)
* [`pnpm-workspace.yaml`](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cR27-R29): Added Angular ESLint plugins and template parser to `peer`.
* [`scripts/typegen.ts`](diffhunk://#diff-090e84b450cb46aeb86f52c80b5e5b04fe62371d940fb2fc06f405f0d172744cL6-R6): Imported and combined Angular and Angular template configurations. [[1]](diffhunk://#diff-090e84b450cb46aeb86f52c80b5e5b04fe62371d940fb2fc06f405f0d172744cL6-R6) [[2]](diffhunk://#diff-090e84b450cb46aeb86f52c80b5e5b04fe62371d940fb2fc06f405f0d172744cR16-R17)

### New Angular Configuration Files:
* [`src/configs/angular.ts`](diffhunk://#diff-321c2c13da640237d16db68795f1a61ccf97925f0313d9e0c296351b4b6efc52R1-R93): Added configuration for Angular with TypeScript support and specific ESLint rules.
* [`src/configs/angular-template.ts`](diffhunk://#diff-6de0027b2f4fa2b7f06575c196a35ad0211c45800d0beb1400668304ee5f36e2R1-R78): Added configuration for Angular templates with specific ESLint rules.

### Rebranding Configurations:
* [`src/configs/formatters.ts`](diffhunk://#diff-dbe739c8bb36148527d27a88a79cb94d9d6eb688448fe3f4bad882f2d439d7eaL94-R94): Updated naming conventions from `antfu` to `thewlabs` for various formatter configurations. [[1]](diffhunk://#diff-dbe739c8bb36148527d27a88a79cb94d9d6eb688448fe3f4bad882f2d439d7eaL94-R94) [[2]](diffhunk://#diff-dbe739c8bb36148527d27a88a79cb94d9d6eb688448fe3f4bad882f2d439d7eaL108-R108) [[3]](diffhunk://#diff-dbe739c8bb36148527d27a88a79cb94d9d6eb688448fe3f4bad882f2d439d7eaL123-R123) [[4]](diffhunk://#diff-dbe739c8bb36148527d27a88a79cb94d9d6eb688448fe3f4bad882f2d439d7eaL138-R138) [[5]](diffhunk://#diff-dbe739c8bb36148527d27a88a79cb94d9d6eb688448fe3f4bad882f2d439d7eaL157-R157) [[6]](diffhunk://#diff-dbe739c8bb36148527d27a88a79cb94d9d6eb688448fe3f4bad882f2d439d7eaL175-R175) [[7]](diffhunk://#diff-dbe739c8bb36148527d27a88a79cb94d9d6eb688448fe3f4bad882f2d439d7eaR189-R196) [[8]](diffhunk://#diff-dbe739c8bb36148527d27a88a79cb94d9d6eb688448fe3f4bad882f2d439d7eaL227-R228) [[9]](diffhunk://#diff-dbe739c8bb36148527d27a88a79cb94d9d6eb688448fe3f4bad882f2d439d7eaL250-R251) [[10]](diffhunk://#diff-dbe739c8bb36148527d27a88a79cb94d9d6eb688448fe3f4bad882f2d439d7eaL273-R274) [[11]](diffhunk://#diff-dbe739c8bb36148527d27a88a79cb94d9d6eb688448fe3f4bad882f2d439d7eaL289-R290) [[12]](diffhunk://#diff-dbe739c8bb36148527d27a88a79cb94d9d6eb688448fe3f4bad882f2d439d7eaL308-R309)

### Index Update:
* [`src/configs/index.ts`](diffhunk://#diff-9b201ba1954f89f2a10c3ae17a59c8193cf82c3ee607bffafb5160d85f4896e5R1-R2): Exported new Angular and Angular template configurations.